### PR TITLE
Fixed the overflow of 'Science Olympiad Foundation' logo in desktop mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
 
             </div>
             <div class="row">
-                <div class="col-2-of-4 feature-box">
+                <div class="col-2-of-4 feature-box exp">
                     <div class="col-1-of-4">
                         <img class="feature-box__image" src="img/sudans.jfif">
                     </div>
@@ -226,7 +226,7 @@
                         </p>
                     </div>
                 </div>
-                <div class="col-2-of-4 feature-box">
+                <div class="col-2-of-4 feature-box exp">
                     <div class="col-1-of-4">
                         <img class="feature-box__image" src="img/dsc.png">
                     </div>
@@ -241,7 +241,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-2-of-4 feature-box">
+                <div class="col-2-of-4 feature-box exp">
                     <div class="col-1-of-4">
                         <img class="feature-box__image" src="img/scienceolp.jpg" max-width=fit-content>
                     </div>
@@ -253,7 +253,7 @@
                         </p>
                     </div>
                 </div>
-                <div class="col-2-of-4 feature-box">
+                <div class="col-2-of-4 feature-box exp">
                     <div class="col-1-of-4">
                         <img class="feature-box__image" src="img/naginalogo.png">
                     </div>

--- a/style.css
+++ b/style.css
@@ -382,6 +382,21 @@ body {
 .feature-box__image {
     height: 11.5rem;
 }
+@media only screen and (min-width: 673px) {
+    .exp{
+        display: flex;
+        align-items: center;
+    }
+    .exp .feature-box__image {
+        height: auto;
+        width: 170%;
+    }
+    .exp .col-1-of-4{
+        margin-right: 6rem;
+        position: relative;
+        right: 3px;
+    }
+}
 
 .feature-box:hover {
     transform: translateY(-1.5rem) scale(1.03);


### PR DESCRIPTION
Used CSS media queries to fix the overflow of **Science Olympiad Foundation** logo in desktop mode only.

### Before:
![image](https://user-images.githubusercontent.com/86077008/135726280-090f127d-d642-479a-8c20-693f4136d5ab.png)


### After:
![image](https://user-images.githubusercontent.com/86077008/135726261-dbddb907-f4ef-45c8-b51c-d21b24923188.png)
